### PR TITLE
AtomicBox should have bounds on its Send/Sync traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,8 @@ criterion = "0.3"
 rand = "0.7"
 rand_distr = "0.2"
 rayon = "1"
+crossbeam-utils = "0.8.1"
+trybuild = "1.0.39"
 
 [[bench]]
 name = "op_ser_benches"

--- a/src/sync/atomics.rs
+++ b/src/sync/atomics.rs
@@ -101,8 +101,8 @@ impl<T: Sized> Drop for AtomicBox<T> {
     }
 }
 
-unsafe impl<T: Sized> Sync for AtomicBox<T> {}
-unsafe impl<T: Sized> Send for AtomicBox<T> {}
+unsafe impl<T: Sized + Sync> Sync for AtomicBox<T> {}
+unsafe impl<T: Sized + Send> Send for AtomicBox<T> {}
 
 #[cfg(test)]
 mod tests {

--- a/tests/atomics.rs
+++ b/tests/atomics.rs
@@ -1,0 +1,5 @@
+#[test]
+fn atomic_box_data_race_regression_test() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/samples/atomic_box_data_race.rs");
+}

--- a/tests/samples/atomic_box_data_race.rs
+++ b/tests/samples/atomic_box_data_race.rs
@@ -1,0 +1,44 @@
+use lever::sync::atomics::AtomicBox;
+
+use crossbeam_utils::thread;
+use std::cell::Cell;
+
+#[derive(Debug, Clone, Copy)]
+enum RefOrInt<'a> {
+    Ref(&'a u64),
+    Int(u64),
+}
+static SOME_INT: u64 = 123;
+
+// https://github.com/vertexclique/lever/issues/15#issue-740069651
+// Run this one in release mode for it to fail
+fn main() {
+    let cell = Cell::new(RefOrInt::Ref(&SOME_INT));
+    let atomic_box = AtomicBox::new(&cell);
+
+    thread::scope(|s| {
+        s.spawn(move |_| {
+            let smuggled_cell = atomic_box.get();
+
+            loop {
+                // Repeatedly write Ref(&addr) and Int(0xdeadbeef) into the cell.
+                smuggled_cell.set(RefOrInt::Ref(&SOME_INT));
+                smuggled_cell.set(RefOrInt::Int(0xdeadbeef));
+            }
+        });
+
+        loop {
+            if let RefOrInt::Ref(addr) = cell.get() {
+                // Hope that between the time we pattern match the object as a
+                // `Ref`, it gets written to by the other thread.
+                if addr as *const u64 == &SOME_INT as *const u64 {
+                    continue;
+                }
+
+                // Due to the data race, obtaining Ref(0xdeadbeef) is possible
+                println!("Pointer is now: {:p}", addr);
+                println!("Dereferencing addr will now segfault: {}", *addr);
+            }
+        }
+    });
+}


### PR DESCRIPTION
There's imo a couple of deprecated things we can update, but it's not as critical as #15 