### PR TITLE
#21 Fix incompatibility with anyhow >1.0.48

### DIFF
--- a/src/table/lotable.rs
+++ b/src/table/lotable.rs
@@ -4,7 +4,7 @@ use crate::txn::prelude::*;
 use std::collections::hash_map::{Iter, Keys, RandomState};
 use std::collections::HashMap;
 
-use anyhow::*;
+use anyhow::Result;
 use std::collections::hash_map;
 use std::fmt;
 use std::hash::Hash;


### PR DESCRIPTION
[anyhow 1.0.49](https://github.com/dtolnay/anyhow/releases/tag/1.0.49) introduced an `Ok` function, which was shadowing `std::result::Result::Ok`