### PR TITLE
Require `FnOnce` instead of `Fn` in `replace_with`

### DIFF
--- a/src/sync/atomics.rs
+++ b/src/sync/atomics.rs
@@ -107,6 +107,13 @@ impl<T: Sized> AtomicBox<T> {
         let ptr = Arc::into_raw(Arc::new(new_val)) as *mut T;
         self.release(ptr);
     }
+
+    ///
+    /// Atomically replace the inner value with the given one.
+    pub fn replace(&self, new_val: T) {
+        let ptr = Arc::into_raw(Arc::new(new_val)) as *mut T;
+        self.release(ptr);
+    }
 }
 
 impl<T: Sized + PartialEq> PartialEq for AtomicBox<T> {

--- a/src/sync/atomics.rs
+++ b/src/sync/atomics.rs
@@ -100,7 +100,7 @@ impl<T: Sized> AtomicBox<T> {
     /// given closure to the current value
     pub fn replace_with<F>(&self, f: F)
     where
-        F: Fn(Arc<T>) -> T,
+        F: FnOnce(Arc<T>) -> T,
     {
         let val = self.take();
         let new_val = f(val);


### PR DESCRIPTION
## Description
This removes `Fn` bound for closures in `replace_with` method of `AtomicBox`.

## Backward compatibility
Since `Fn` is the subset of all closure types, it is guaranteed that this commit will not break code that use the old method signature.

## Forward compatibility
Once the signature is changed to `FnOnce`, going back might break things. 