### PR TITLE
Implement `replace()` method for `AtomicBox`

### DIFF
--- a/src/htm/ops.rs
+++ b/src/htm/ops.rs
@@ -93,7 +93,7 @@ mod lever_hwtxn_test {
 
     pub fn swallow<T>(d: T) -> T {
         unsafe {
-            core::arch::asm!("" : : "r"(&d));
+            llvm_asm!("" : : "r"(&d));
             d
         }
     }

--- a/src/htm/ops.rs
+++ b/src/htm/ops.rs
@@ -93,7 +93,7 @@ mod lever_hwtxn_test {
 
     pub fn swallow<T>(d: T) -> T {
         unsafe {
-            llvm_asm!("" : : "r"(&d));
+            core::arch::asm!("" : : "r"(&d));
             d
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 // Behind the feature gates
-#![cfg_attr(feature = "hw", feature(stdsimd))]
+#![cfg_attr(feature = "hw", feature(portable_simd))]
 #![cfg_attr(feature = "hw", feature(llvm_asm))]
 // FIXME: Baking still
 #![allow(dead_code)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 // Behind the feature gates
 #![cfg_attr(feature = "hw", feature(portable_simd))]
-#![cfg_attr(feature = "hw", feature(llvm_asm))]
 #![cfg_attr(feature = "hw", feature(stdarch_x86_rtm))]
 // FIXME: Baking still
 #![allow(dead_code)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 // Behind the feature gates
 #![cfg_attr(feature = "hw", feature(portable_simd))]
+#![cfg_attr(feature = "hw", feature(llvm_asm))]
 #![cfg_attr(feature = "hw", feature(stdarch_x86_rtm))]
 // FIXME: Baking still
 #![allow(dead_code)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 // Behind the feature gates
 #![cfg_attr(feature = "hw", feature(portable_simd))]
 #![cfg_attr(feature = "hw", feature(llvm_asm))]
+#![cfg_attr(feature = "hw", feature(stdarch_x86_rtm))]
 // FIXME: Baking still
 #![allow(dead_code)]
 #![allow(unused_imports)]

--- a/src/sync/atomics.rs
+++ b/src/sync/atomics.rs
@@ -107,6 +107,13 @@ impl<T: Sized> AtomicBox<T> {
         let ptr = Arc::into_raw(Arc::new(new_val)) as *mut T;
         self.release(ptr);
     }
+
+    ///
+    /// Atomically replace the inner value with the given one.
+    pub fn replace(&self, new_val: T) {
+        let ptr = Arc::into_raw(Arc::new(new_val)) as *mut T;
+        self.release(ptr);
+    }
 }
 
 impl<T: Sized + PartialEq> PartialEq for AtomicBox<T> {


### PR DESCRIPTION
This implements a method on `AtomicBox` that will allow you to replace the inner value with the given one, and without a closure.